### PR TITLE
Fixed syntax error for dot product

### DIFF
--- a/vectors/vectors.py
+++ b/vectors/vectors.py
@@ -148,7 +148,7 @@ class Vector(Point):
             return (self.magnitude() * vector.magnitude() *
                     math.degrees(math.cos(theta)))
         return (reduce(lambda x, y: x + y,
-                [x * vector.vector[i] for i, x in self.to_list()()]))
+                [x * vector.to_list()[i] for i, x in enumerate(self.to_list())]))
 
     def cross(self, vector):
         """Return a Vector instance as the cross product of two vectors"""


### PR DESCRIPTION
Fixed a bug introduced by the removal of the `vector` property in this commit:

https://github.com/allelos/vectors/commit/487bcbe287eff6ad1b5e5299ff35e3b20bdd695d

This isn't super pretty, I have no opinion either way on reintroducing that property. It might be more worthwhile in order to avoid breaking the API for others using this project.